### PR TITLE
Fix: ORCA reader in case of an one column block

### DIFF
--- a/src/orca.py
+++ b/src/orca.py
@@ -81,7 +81,8 @@ def parse_orca_output(out_data):
 
         h = np.loadtxt(s, skiprows=1,
                        converters=dict((i+1, float) for i in range(batch_size)),
-                       usecols=tuple(i+1 for i in range(batch_size)))
+                       usecols=tuple(i+1 for i in range(batch_size)),
+                       ndmin=2)
 
         hessian = h if hessian is None else np.hstack((hessian, h))
 


### PR DESCRIPTION
Please merge this little fix for cases when the hessian block consists only of one column. The numpy reader then reads the column into a single vector rather than a 1 x n matrix.