### PR TITLE
extend debug flag to cover all print statements

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -18,7 +18,7 @@ class Config(object):
                 print_message = False
         except:
             pass
-        if print_message:
+        if print_message and settings.DEBUG >= 2:
             print("\nReading configuration from {0}".format(filename))
 
         # a list of isotopologues

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
 # This file reads PyQuiver configuration files. 
 import sys
 import re
+import settings
 from constants import REPLACEMENTS, REPLACEMENTS_Z
 from collections import OrderedDict
 

--- a/src/quiver.py
+++ b/src/quiver.py
@@ -254,7 +254,8 @@ class System(object):
                 if detected_indep:
                     break
         linear_string = "linear" if self.is_linear else "not linear"
-        print("Molecule is %s." % linear_string)
+        if settings.DEBUG >= 2:
+            print("Molecule is %s." % linear_string)
         self.atomic_numbers = atomic_numbers
 
     def dump_debug(self, obj):


### PR DESCRIPTION
Hey Eugene,

I added a few lines to prevent the same settings messages from printing over and over again when you run PyQuiver on hundreds of files. 

Corin